### PR TITLE
Issue #1 : use felix plugin to add OSGi metadata during build

### DIFF
--- a/management-model/pom.xml
+++ b/management-model/pom.xml
@@ -44,6 +44,20 @@
           <target>${java.version}</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.5.4</version>
+        <executions>
+          <execution>
+            <id>generate-osgi-headers</id>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
@ljacomet : I just added the basic information, just like you did for offheap-store; it should be enough since this module does not depend on anything, and it is a module that only provides model.

On a side note : this module (management-model) is optional for core, but mandatory for 107 (since 107 requires management that itself requires terracotta-management)

Finally, I did not add anything to management-model-json, since we're discussing its deprecation atm.