### PR TITLE
Finally, management metadata needs to be exposed under platform/clients

### DIFF
--- a/management-entity/management-entity-common/src/main/java/org/terracotta/management/entity/ManagementAgent.java
+++ b/management-entity/management-entity-common/src/main/java/org/terracotta/management/entity/ManagementAgent.java
@@ -17,7 +17,6 @@ package org.terracotta.management.entity;
 
 import org.terracotta.management.model.capabilities.Capability;
 import org.terracotta.management.model.cluster.ClientIdentifier;
-import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.voltron.proxy.Async;
 import org.terracotta.voltron.proxy.ClientId;
@@ -33,14 +32,21 @@ public interface ManagementAgent {
   /**
    * Exposes this management registry output (context container and capabilities) over this connection.
    *
-   * @param entity           The management context for the entity, from {@link #getEntityContexts(Object)}
    * @param contextContainer output from Management registry
    * @param capabilities     output from Management registry
+   * @param clientDescriptor must be null, used only for implementation
+   */
+  @Async(Async.Ack.NONE)
+  Future<Void> exposeManagementMetadata(@ClientId Object clientDescriptor, ContextContainer contextContainer, Collection<Capability> capabilities);
+
+  /**
+   * Exposes client tags
+   *
    * @param clientDescriptor must be null, used only for implementation
    * @param tags             the tags to expose for this client
    */
   @Async(Async.Ack.NONE)
-  Future<Void> expose(Context entity, ContextContainer contextContainer, Collection<Capability> capabilities, Collection<String> tags, @ClientId Object clientDescriptor);
+  Future<Void> exposeTags(@ClientId Object clientDescriptor, Collection<String> tags);
 
   /**
    * Gets the {@link ClientIdentifier} for the underlying logical connection.
@@ -49,13 +55,5 @@ public interface ManagementAgent {
    */
   @Async(Async.Ack.NONE)
   Future<ClientIdentifier> getClientIdentifier(@ClientId Object clientDescriptor);
-
-  /**
-   * Gets the list of all management {@link Context} for the underlying logical connection, representing the different kinds of entities fetched on the server.
-   *
-   * @param clientDescriptor must be null, used only for implementation
-   */
-  @Async(Async.Ack.NONE)
-  Future<Collection<Context>> getEntityContexts(@ClientId Object clientDescriptor);
 
 }

--- a/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/ManagementAgentImpl.java
+++ b/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/ManagementAgentImpl.java
@@ -18,35 +18,26 @@ package org.terracotta.management.entity.server;
 import org.terracotta.management.entity.ManagementAgent;
 import org.terracotta.management.entity.ManagementAgentConfig;
 import org.terracotta.management.model.capabilities.Capability;
-import org.terracotta.management.model.cluster.Client;
 import org.terracotta.management.model.cluster.ClientIdentifier;
-import org.terracotta.management.model.cluster.Manageable;
-import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.service.monitoring.IMonitoringConsumer;
 import org.terracotta.monitoring.IMonitoringProducer;
 import org.terracotta.monitoring.PlatformClientFetchedEntity;
 import org.terracotta.monitoring.PlatformConnectedClient;
-import org.terracotta.monitoring.PlatformEntity;
 import org.terracotta.voltron.proxy.ClientId;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.terracotta.management.entity.server.Utils.array;
 import static org.terracotta.monitoring.PlatformMonitoringConstants.CLIENTS_PATH;
-import static org.terracotta.monitoring.PlatformMonitoringConstants.ENTITIES_PATH;
+import static org.terracotta.monitoring.PlatformMonitoringConstants.CLIENTS_ROOT_NAME;
 import static org.terracotta.monitoring.PlatformMonitoringConstants.FETCHED_PATH;
-import static org.terracotta.monitoring.PlatformMonitoringConstants.FETCHED_ROOT_NAME;
 import static org.terracotta.monitoring.PlatformMonitoringConstants.PLATFORM_ROOT_NAME;
 
 /**
@@ -58,9 +49,9 @@ import static org.terracotta.monitoring.PlatformMonitoringConstants.PLATFORM_ROO
  * </ul>
  * Produces:
  * <ul>
- * <li>{@code platform/fetched/<id>/contextContainer ContextContainer}</li>
- * <li>{@code platform/fetched/<id>/capabilities Collections<Capability>}</li>
- * <li>{@code platform/fetched/<id>/tags Collections<String>}</li>
+ * <li>{@code platform/clients/<id>/tags Collections<String>}</li>
+ * <li>{@code platform/clients/<id>/management/<id>/contextContainer ContextContainer}</li>
+ * <li>{@code platform/clients/<id>/management/<id>/capabilities Collections<Capability>}</li>
  * </ul>
  *
  * @author Mathieu Carbou
@@ -85,63 +76,33 @@ class ManagementAgentImpl implements ManagementAgent {
   }
 
   @Override
-  public Future<Collection<Context>> getEntityContexts(@ClientId Object clientDescriptor) {
-    Map.Entry<String, PlatformConnectedClient> platformConnectedClient = getPlatformConnectedClient(clientDescriptor);
-    ClientIdentifier clientIdentifier = toClientIdentifier(platformConnectedClient.getValue());
-    Context parent = Context.create(Client.KEY, clientIdentifier.getClientId());
+  public Future<Void> exposeManagementMetadata(@ClientId Object clientDescriptor, ContextContainer contextContainer, Collection<Capability> capabilities) {
+    // get the connection info
+    Map.Entry<String, PlatformConnectedClient> entry = getPlatformConnectedClient(clientDescriptor);
 
-    return CompletableFuture.completedFuture(getPlatformClientFetchedEntities(platformConnectedClient.getKey())
-        .map(entry -> {
+    String key = contextContainer.getName() + ":" + contextContainer.getValue();
+    String[] clientPath = array(PLATFORM_ROOT_NAME, CLIENTS_ROOT_NAME, entry.getKey());
+    String[] managementRoot = array(PLATFORM_ROOT_NAME, CLIENTS_ROOT_NAME, entry.getKey(), "management");
+    String[] managementPath = array(PLATFORM_ROOT_NAME, CLIENTS_ROOT_NAME, entry.getKey(), "management", key);
 
-          Optional<PlatformEntity> platformEntity = consumer.getValueForNode(ENTITIES_PATH, entry.getValue().entityIdentifier, PlatformEntity.class);
-          if (!platformEntity.isPresent()) {
-            return Context.empty();
-          }
-
-          // create a manageable just to build a context object easily. we could have just set the keys by our own instead.
-          Manageable manageable = Manageable.create(platformEntity.get().name, platformEntity.get().typeName);
-
-          consumer.getValueForNode(array(PLATFORM_ROOT_NAME, FETCHED_ROOT_NAME, entry.getKey(), "contextContainer"), ContextContainer.class)
-              .ifPresent(manageable::setContextContainer);
-
-          return parent.with(manageable.getContext());
-        })
-        .distinct()
-        .collect(Collectors.toList()));
-  }
-
-  @Override
-  public Future<Void> expose(Context entityContext, ContextContainer contextContainer, Collection<Capability> capabilities, Collection<String> tags, @ClientId Object clientDescriptor) {
-    if (!entityContext.contains(Manageable.NAME_KEY) || !entityContext.contains(Manageable.TYPE_KEY)) {
-      throw new IllegalArgumentException("Bad entity context: " + entityContext);
+    // ensure the root is there
+    if (!consumer.getValueForNode(managementRoot, Object.class).isPresent()) {
+      producer.addNode(clientPath, "management", null);
     }
 
-    // get the connection info
-    Map.Entry<String, PlatformConnectedClient> platformConnectedClient = getPlatformConnectedClient(clientDescriptor);
-
-    // iterate over all fetched entities iver this connection to find the "fetch" representing this context
-    // once found, we pout in the tree the management metadata, under platform/fetched/<id>/contextContainer and platform/fetched/<id>/capabilities
-    getPlatformClientFetchedEntities(platformConnectedClient.getKey())
-        .forEach(entry -> consumer.getValueForNode(ENTITIES_PATH, entry.getValue().entityIdentifier, PlatformEntity.class)
-            .filter(platformEntity -> platformEntity.name.equals(entityContext.get(Manageable.NAME_KEY)) && platformEntity.typeName.equals(entityContext.get(Manageable.TYPE_KEY)))
-            .ifPresent(platformEntity -> {
-              producer.addNode(array(PLATFORM_ROOT_NAME, FETCHED_ROOT_NAME, entry.getKey()), "contextContainer", contextContainer);
-              producer.addNode(array(PLATFORM_ROOT_NAME, FETCHED_ROOT_NAME, entry.getKey()), "capabilities", capabilities);
-              producer.addNode(array(PLATFORM_ROOT_NAME, FETCHED_ROOT_NAME, entry.getKey()), "tags", tags == null ? Collections.emptyList() : tags);
-            }));
+    producer.addNode(managementRoot, key, null);
+    producer.addNode(managementPath, "contextContainer", contextContainer);
+    producer.addNode(managementPath, "capabilities", capabilities);
 
     return CompletableFuture.completedFuture(null);
   }
 
-  // returns all the fetched entities over a connection
-  private Stream<? extends Map.Entry<String, PlatformClientFetchedEntity>> getPlatformClientFetchedEntities(String clientIdentifier) {
-    return consumer.getChildValuesForNode(FETCHED_PATH)
-        .map(children -> children.entrySet()
-            .stream()
-            .filter(entry -> entry.getValue() instanceof PlatformClientFetchedEntity)
-            .map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), (PlatformClientFetchedEntity) entry.getValue()))
-            .filter(entry -> entry.getValue().clientIdentifier.equals(clientIdentifier)))
-        .orElseThrow(() -> new IllegalStateException("No entities have been fetched"));
+  @Override
+  public Future<Void> exposeTags(@ClientId Object clientDescriptor, Collection<String> tags) {
+    // get the connection info
+    Map.Entry<String, PlatformConnectedClient> entry = getPlatformConnectedClient(clientDescriptor);
+    producer.addNode(array(PLATFORM_ROOT_NAME, CLIENTS_ROOT_NAME, entry.getKey()), "tags", tags == null ? Collections.emptyList() : tags);
+    return CompletableFuture.completedFuture(null);
   }
 
   // return the PlatformConnectedClient object representing the connection used by this clientDescriptor


### PR DESCRIPTION
otherwise cannot consolidate client management metadata in M&M Entity.

This is also to allowed for future monitoring of standalone products, without the need of clustered entities.