### PR TITLE
management entity client descriptor could not be there

### DIFF
--- a/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/ManagementAgentImpl.java
+++ b/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/ManagementAgentImpl.java
@@ -61,23 +61,24 @@ class ManagementAgentImpl implements ManagementAgent {
 
   @Override
   public Future<ClientIdentifier> getClientIdentifier(@ClientId Object clientDescriptor) {
-    return CompletableFuture.completedFuture(Utils.getClientIdentifier(consumer, clientDescriptor));
+    return CompletableFuture.completedFuture(Utils.getClientIdentifier(consumer, clientDescriptor).get());
   }
 
   @Override
   public Future<Void> exposeManagementMetadata(@ClientId Object clientDescriptor, ContextContainer contextContainer, Capability... capabilities) {
-    ClientIdentifier clientIdentifier = Utils.getClientIdentifier(consumer, clientDescriptor);
-    String name = contextContainer.getName() + ":" + contextContainer.getValue();
-    producer.addNode(array("management", "clients", clientIdentifier.getClientId()), name, null);
-    producer.addNode(array("management", "clients", clientIdentifier.getClientId(), name), "contextContainer", contextContainer);
-    producer.addNode(array("management", "clients", clientIdentifier.getClientId(), name), "capabilities", capabilities);
+    Utils.getClientIdentifier(consumer, clientDescriptor).ifPresent(clientIdentifier -> {
+      String name = contextContainer.getName() + ":" + contextContainer.getValue();
+      producer.addNode(array("management", "clients", clientIdentifier.getClientId()), name, null);
+      producer.addNode(array("management", "clients", clientIdentifier.getClientId(), name), "contextContainer", contextContainer);
+      producer.addNode(array("management", "clients", clientIdentifier.getClientId(), name), "capabilities", capabilities);
+    });
     return CompletableFuture.completedFuture(null);
   }
 
   @Override
   public Future<Void> exposeTags(@ClientId Object clientDescriptor, String... tags) {
-    ClientIdentifier clientIdentifier = Utils.getClientIdentifier(consumer, clientDescriptor);
-    producer.addNode(array("management", "clients", clientIdentifier.getClientId()), "tags", tags == null ? new String[0] : tags);
+    Utils.getClientIdentifier(consumer, clientDescriptor).ifPresent(clientIdentifier ->
+        producer.addNode(array("management", "clients", clientIdentifier.getClientId()), "tags", tags == null ? new String[0] : tags));
     return CompletableFuture.completedFuture(null);
   }
 

--- a/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/ManagementAgentServerEntity.java
+++ b/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/ManagementAgentServerEntity.java
@@ -19,7 +19,6 @@ package org.terracotta.management.entity.server;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.management.entity.ManagementAgent;
 import org.terracotta.management.entity.ManagementAgentConfig;
-import org.terracotta.management.model.cluster.ClientIdentifier;
 import org.terracotta.management.service.monitoring.IMonitoringConsumer;
 import org.terracotta.monitoring.IMonitoringProducer;
 import org.terracotta.voltron.proxy.server.ProxiedServerEntity;
@@ -56,15 +55,17 @@ class ManagementAgentServerEntity extends ProxiedServerEntity<ManagementAgent> {
     super.connected(clientDescriptor);
 
     // when an entity is fetched, we create the root /management/<id> (ClientDescriptor)
-    ClientIdentifier identifier = getClientIdentifier(consumer, clientDescriptor);
-    producer.addNode(array("management", "clients"), identifier.getClientId(), clientDescriptor);
+    getClientIdentifier(consumer, clientDescriptor).ifPresent(clientIdentifier -> {
+      producer.addNode(array("management", "clients"), clientIdentifier.getClientId(), clientDescriptor);
+    });
   }
 
   @Override
   public void disconnected(ClientDescriptor clientDescriptor) {
     // when an entity is closed, we remove the node /management/<id> having the same ClientDescriptor
-    ClientIdentifier identifier = getClientIdentifier(consumer, clientDescriptor);
-    producer.removeNode(array("management", "clients"), identifier.getClientId());
+    getClientIdentifier(consumer, clientDescriptor).ifPresent(clientIdentifier -> {
+      producer.removeNode(array("management", "clients"), clientIdentifier.getClientId());
+    });
 
     super.disconnected(clientDescriptor);
   }

--- a/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/Utils.java
+++ b/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/Utils.java
@@ -37,16 +37,15 @@ class Utils {
     return o;
   }
 
-  static ClientIdentifier getClientIdentifier(IMonitoringConsumer consumer, Object clientDescriptor) {
-    return toClientIdentifier(getPlatformConnectedClient(consumer, clientDescriptor).getValue());
+  static Optional<ClientIdentifier> getClientIdentifier(IMonitoringConsumer consumer, Object clientDescriptor) {
+    return getPlatformConnectedClient(consumer, clientDescriptor).map(entry -> toClientIdentifier(entry.getValue()));
   }
 
   // return the PlatformConnectedClient object representing the connection used by this clientDescriptor
-  private static Map.Entry<String, PlatformConnectedClient> getPlatformConnectedClient(IMonitoringConsumer consumer, Object clientDescriptor) {
+  private static Optional<Map.Entry<String, PlatformConnectedClient>> getPlatformConnectedClient(IMonitoringConsumer consumer, Object clientDescriptor) {
     return getPlatformClientFetchedEntity(consumer, clientDescriptor)
         .flatMap(entry -> consumer.getValueForNode(CLIENTS_PATH, entry.getValue().clientIdentifier, PlatformConnectedClient.class)
-            .map(platformConnectedClient -> new AbstractMap.SimpleEntry<>(entry.getValue().clientIdentifier, platformConnectedClient)))
-        .orElseThrow(() -> new IllegalStateException("Unable to find fetch information matching client descriptor " + clientDescriptor));
+            .map(platformConnectedClient -> new AbstractMap.SimpleEntry<>(entry.getValue().clientIdentifier, platformConnectedClient)));
   }
 
   // return the PlatformClientFetchedEntity object linked to this clientDescriptor


### PR DESCRIPTION
Fixed potential crash on voltron disconnected() callback.

@GaryWKeim : this will prevent voltron server from crashing when calling `cacheManager.close()`